### PR TITLE
feature: Add AsRef<Vec<u8>> as a type constraint for Mbc trait

### DIFF
--- a/crates/memory/src/bios.rs
+++ b/crates/memory/src/bios.rs
@@ -37,6 +37,23 @@ impl MemoryBus for Bios {
     }
 }
 
+impl Bios {
+    pub fn new() -> Self {
+        let output = std::process::Command::new("git")
+            .args(&["rev-parse", "--show-toplevel"])
+            .output()
+            .unwrap();
+        let git_root = str::from_utf8(&output.stdout).unwrap().trim();
+        let mut path = PathBuf::new();
+        path.push(git_root);
+        path.push("ressources/bios/dmg_boot.bin");
+        println!("path: {:?}", path);
+        let data = fs::read(path).unwrap();
+        Bios { data }
+    }
+
+}
+
 #[cfg(test)]
 mod test_bios {
     //use super::Bios;

--- a/crates/memory/src/bios.rs
+++ b/crates/memory/src/bios.rs
@@ -1,8 +1,8 @@
 use crate::MemoryBus;
+use std::convert::AsRef;
 use std::fs;
 use std::path::PathBuf;
 use std::str;
-use std::convert::AsRef;
 
 #[derive(Debug)]
 pub struct Bios {
@@ -51,7 +51,6 @@ impl Bios {
         let data = fs::read(path).unwrap();
         Bios { data }
     }
-
 }
 
 #[cfg(test)]

--- a/crates/memory/src/bios.rs
+++ b/crates/memory/src/bios.rs
@@ -2,6 +2,7 @@ use crate::MemoryBus;
 use std::fs;
 use std::path::PathBuf;
 use std::str;
+use std::convert::AsRef;
 
 #[derive(Debug)]
 pub struct Bios {
@@ -14,19 +15,9 @@ impl Default for Bios {
     }
 }
 
-impl Bios {
-    pub fn new() -> Self {
-        let output = std::process::Command::new("git")
-            .args(&["rev-parse", "--show-toplevel"])
-            .output()
-            .unwrap();
-        let git_root = str::from_utf8(&output.stdout).unwrap().trim();
-        let mut path = PathBuf::new();
-        path.push(git_root);
-        path.push("ressources/bios/dmg_boot.bin");
-        println!("path: {:?}", path);
-        let data = fs::read(path).unwrap();
-        Bios { data }
+impl AsRef<Vec<u8>> for Bios {
+    fn as_ref(&self) -> &Vec<u8> {
+        self.data.as_ref()
     }
 }
 

--- a/crates/memory/src/bus.rs
+++ b/crates/memory/src/bus.rs
@@ -1,4 +1,6 @@
-pub trait MemoryBus: std::fmt::Debug {
+use std::convert::AsRef;
+
+pub trait MemoryBus: std::fmt::Debug + AsRef<Vec<u8>> {
     fn get(&self, _: usize) -> u8;
     fn set(&mut self, _: usize, data: u8);
 }

--- a/crates/memory/src/mbc/bus.rs
+++ b/crates/memory/src/mbc/bus.rs
@@ -1,8 +1,9 @@
 use crate::MemoryBus;
 use shared::Error;
+use std::convert::AsRef;
 
 pub trait MbcBus: std::fmt::Debug {
     fn set(&mut self, address: usize, data: u8) -> Result<(), Error>;
 }
 
-pub trait Mbc: MbcBus + MemoryBus {}
+pub trait Mbc: MbcBus + MemoryBus + AsRef<Vec<u8>> {}

--- a/crates/memory/src/mbc/bus.rs
+++ b/crates/memory/src/mbc/bus.rs
@@ -1,9 +1,8 @@
 use crate::MemoryBus;
 use shared::Error;
-use std::convert::AsRef;
 
 pub trait MbcBus: std::fmt::Debug {
     fn set(&mut self, address: usize, data: u8) -> Result<(), Error>;
 }
 
-pub trait Mbc: MbcBus + MemoryBus + AsRef<Vec<u8>> {}
+pub trait Mbc: MbcBus + MemoryBus {}

--- a/crates/memory/src/mbc/mbc0.rs
+++ b/crates/memory/src/mbc/mbc0.rs
@@ -3,10 +3,25 @@ use super::consts;
 use super::Mbc;
 use crate::MemoryBus;
 use shared::Error;
+use std::convert::AsRef;
 
 #[derive(Debug)]
 pub struct Mbc0 {
     data: Vec<u8>,
+}
+
+impl Default for Mbc0 {
+    fn default() -> Self {
+        Mbc0 {
+            data: vec![0; consts::MBC0_MAX_SIZE],
+        }
+    }
+}
+
+impl AsRef<Vec<u8>> for Mbc0 {
+    fn as_ref(&self) -> &Vec<u8> {
+        self.data.as_ref()
+    }
 }
 
 impl MbcBus for Mbc0 {
@@ -28,14 +43,6 @@ impl Mbc for Mbc0 {}
 impl Mbc0 {
     pub fn new(data: Vec<u8>) -> Box<Self> {
         Box::new(Self { data })
-    }
-}
-
-impl Default for Mbc0 {
-    fn default() -> Self {
-        Mbc0 {
-            data: vec![0; consts::MBC0_MAX_SIZE],
-        }
     }
 }
 

--- a/crates/memory/src/mbc/mbc1.rs
+++ b/crates/memory/src/mbc/mbc1.rs
@@ -3,6 +3,7 @@ use super::consts;
 use super::Mbc;
 use crate::MemoryBus;
 use shared::Error;
+use std::convert::AsRef;
 
 #[derive(Debug)]
 pub struct Mbc1 {
@@ -12,6 +13,24 @@ pub struct Mbc1 {
     data: Vec<u8>,
     rom_bank: u8,
     ram_bank: u8,
+}
+
+impl Default for Mbc1 {
+    fn default() -> Self {
+        Mbc1 {
+            ram_lock: false,
+            bank_mode: false,
+            data: vec![0; consts::MBC1_MAX_SIZE],
+            rom_bank: 0,
+            ram_bank: 0,
+        }
+    }
+}
+
+impl AsRef<Vec<u8>> for Mbc1 {
+    fn as_ref(&self) -> &Vec<u8> {
+        self.data.as_ref()
+    }
 }
 
 impl MbcBus for Mbc1 {
@@ -137,18 +156,6 @@ impl Mbc1 {
     fn update_ram_lock(&mut self, data: u8) -> Result<(), Error> {
         self.ram_lock = data == consts::MBC_MAGIC_LOCK;
         Ok(())
-    }
-}
-
-impl Default for Mbc1 {
-    fn default() -> Self {
-        Mbc1 {
-            ram_lock: false,
-            bank_mode: false,
-            data: vec![0; consts::MBC1_MAX_SIZE],
-            rom_bank: 0,
-            ram_bank: 0,
-        }
     }
 }
 

--- a/crates/memory/src/mbc/mbc2.rs
+++ b/crates/memory/src/mbc/mbc2.rs
@@ -3,6 +3,7 @@ use super::consts;
 use super::Mbc;
 use crate::MemoryBus;
 use shared::Error;
+use std::convert::AsRef;
 
 #[derive(Debug)]
 pub struct Mbc2 {
@@ -10,6 +11,22 @@ pub struct Mbc2 {
     data: Vec<u8>,
     /// Max 16 0x00 ..= 0x0f
     rom_bank: u8,
+}
+
+impl Default for Mbc2 {
+    fn default() -> Self {
+        Mbc2 {
+            ram_lock: false,
+            data: vec![0; consts::MBC2_MAX_SIZE],
+            rom_bank: 1,
+        }
+    }
+}
+
+impl AsRef<Vec<u8>> for Mbc2 {
+    fn as_ref(&self) -> &Vec<u8> {
+        self.data.as_ref()
+    }
 }
 
 impl MbcBus for Mbc2 {
@@ -80,16 +97,6 @@ impl Mbc2 {
             consts::MBC_RAM_START..=consts::MBC2_RAM_END => consts::MBC_RAM_START,
             consts::MBC2_ERAM_START..=consts::MBC2_ERAM_END => consts::MBC2_ERAM_START,
             _ => unreachable!(),
-        }
-    }
-}
-
-impl Default for Mbc2 {
-    fn default() -> Self {
-        Mbc2 {
-            ram_lock: false,
-            data: vec![0; consts::MBC2_MAX_SIZE],
-            rom_bank: 1,
         }
     }
 }

--- a/crates/memory/src/mbc/mbc3.rs
+++ b/crates/memory/src/mbc/mbc3.rs
@@ -3,6 +3,7 @@ use super::consts;
 use super::Mbc;
 use crate::MemoryBus;
 use shared::Error;
+use std::convert::AsRef;
 
 /// Return the epoch in microseconds.
 fn get_epoch() -> u64 {
@@ -20,6 +21,32 @@ pub struct Mbc3 {
     rom_bank: u8,
     ram_bank: u8,
     rtc: Mbc3Rtc,
+}
+
+impl Default for Mbc3 {
+    fn default() -> Self {
+        Mbc3 {
+            ram_lock: false,
+            latch: false,
+            data: vec![0; consts::MBC3_MAX_SIZE],
+            rom_bank: 0,
+            ram_bank: 0,
+            rtc: Mbc3Rtc {
+                seconds: 3,
+                minutes: 2,
+                hours: 1,
+                dc_lower: 0,
+                dc_upper: 0,
+                epoch: 0,
+            },
+        }
+    }
+}
+
+impl AsRef<Vec<u8>> for Mbc3 {
+    fn as_ref(&self) -> &Vec<u8> {
+        self.data.as_ref()
+    }
 }
 
 /// [Name]    [Range]  [Id]    [Description]
@@ -230,26 +257,6 @@ impl Mbc3 {
         let day = epoch / (3600 * 24);
         self.rtc.dc_lower = day as u8;
         self.rtc.dc_upper = (self.rtc.dc_upper & !1) | ((day >> 8) & 1) as u8;
-    }
-}
-
-impl Default for Mbc3 {
-    fn default() -> Self {
-        Mbc3 {
-            ram_lock: false,
-            latch: false,
-            data: vec![0; consts::MBC3_MAX_SIZE],
-            rom_bank: 0,
-            ram_bank: 0,
-            rtc: Mbc3Rtc {
-                seconds: 3,
-                minutes: 2,
-                hours: 1,
-                dc_lower: 0,
-                dc_upper: 0,
-                epoch: 0,
-            },
-        }
     }
 }
 

--- a/crates/memory/src/mbc/mbc5.rs
+++ b/crates/memory/src/mbc/mbc5.rs
@@ -3,6 +3,7 @@ use super::consts;
 use super::Mbc;
 use crate::MemoryBus;
 use shared::Error;
+use std::convert::AsRef;
 
 #[derive(Debug)]
 pub struct Mbc5 {
@@ -10,6 +11,23 @@ pub struct Mbc5 {
     data: Vec<u8>,
     rom_bank: u16,
     ram_bank: u8,
+}
+
+impl Default for Mbc5 {
+    fn default() -> Self {
+        Mbc5 {
+            ram_lock: false,
+            data: vec![0; consts::MBC5_MAX_SIZE],
+            rom_bank: 0,
+            ram_bank: 0,
+        }
+    }
+}
+
+impl AsRef<Vec<u8>> for Mbc5 {
+    fn as_ref(&self) -> &Vec<u8> {
+        self.data.as_ref()
+    }
 }
 
 impl MbcBus for Mbc5 {
@@ -110,17 +128,6 @@ impl Mbc5 {
     fn update_ram_lock(&mut self, data: u8) -> Result<(), Error> {
         self.ram_lock = data == consts::MBC_MAGIC_LOCK;
         Ok(())
-    }
-}
-
-impl Default for Mbc5 {
-    fn default() -> Self {
-        Mbc5 {
-            ram_lock: false,
-            data: vec![0; consts::MBC5_MAX_SIZE],
-            rom_bank: 0,
-            ram_bank: 0,
-        }
     }
 }
 

--- a/crates/memory/src/wram.rs
+++ b/crates/memory/src/wram.rs
@@ -30,6 +30,14 @@ impl MemoryBus for Wram {
     }
 }
 
+impl Wram {
+    pub fn new() -> Self {
+        Wram {
+            data: vec![0; WRAM_SIZE],
+        }
+    }
+}
+
 #[cfg(test)]
 mod test_wram {
     use super::Wram;

--- a/crates/memory/src/wram.rs
+++ b/crates/memory/src/wram.rs
@@ -1,10 +1,11 @@
 use crate::MemoryBus;
+use std::convert::AsRef;
 
 const WRAM_SIZE: usize = 8192;
 
 #[derive(Debug)]
 pub struct Wram {
-    data: [u8; WRAM_SIZE],
+    data: Vec<u8>,
 }
 
 impl Default for Wram {
@@ -13,11 +14,9 @@ impl Default for Wram {
     }
 }
 
-impl Wram {
-    pub fn new() -> Self {
-        Wram {
-            data: [0; WRAM_SIZE],
-        }
+impl AsRef<Vec<u8>> for Wram {
+    fn as_ref(&self) -> &Vec<u8> {
+        self.data.as_ref()
     }
 }
 

--- a/crates/ui/src/debugger/memory_map.rs
+++ b/crates/ui/src/debugger/memory_map.rs
@@ -1,4 +1,3 @@
-//mod memory;
 use super::widgets::hexdump;
 use crate::style::Theme;
 use iced_wgpu::{scrollable, Renderer, Scrollable};


### PR DESCRIPTION
- Impl AsRef for Bios
- Move impl Bios in file
- Impl AsRef for Mbc0
- Impl AsRef for Wram
- Move impl Wram
- Impl AsRef for Mbc1
- Impl AsRef for Mbc2
- Impl AsRef for Mbc3
- Impl AsRef for Mbc5
- Add AsRef as type constraint for Mbc trait
- Format code
